### PR TITLE
Remove PHP CodeSniffer from Composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit",
-        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+        "test": "phpunit"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8.0",
-        "squizlabs/php_codesniffer": "^3.1",
         "orchestra/testbench": "^3.8"
     },
     "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This removes [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) as a dependency for styling and to finalise the move to [Style CI](https://styleci.io).

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
